### PR TITLE
chore: opt tag query

### DIFF
--- a/comp.go
+++ b/comp.go
@@ -55,10 +55,10 @@ type OptComp[T any] struct {
 // Present reports whether T exists on the current chunk or entity.
 func (c *OptComp[T]) Present(cur *Cursor) bool { return c.col.Present(cur) }
 
-// Slice returns T's slice for the current All-mode chunk, or nil if absent.
+// Slice returns T's slice for the current All-mode chunk (data-free values for a zero-size tag T), or nil if absent.
 func (c *OptComp[T]) Slice(cur *Cursor) []T { return c.col.Slice(cur) }
 
-// At returns a pointer to T for the current Pick/Seek-mode entity, or nil if absent.
+// At returns a pointer to T for the current Pick/Seek-mode entity (a data-free value for a zero-size tag T), or nil if absent.
 func (c *OptComp[T]) At(cur *Cursor) *T { return c.col.At(cur) }
 
 // OptTrackable is satisfied by *OptComp[T] for any T — it lets

--- a/internal/colstore/table.go
+++ b/internal/colstore/table.go
@@ -95,14 +95,18 @@ func (t *Table) BakeOffsets(ids []comp.ID) []uintptr {
 	return offsets
 }
 
-// BakeOptional is BakeOffsets plus a per-id presence flag.
-func (t *Table) BakeOptional(ids []comp.ID) (offsets []uintptr, present []bool) {
+// BakeOptional is BakeOffsets plus a per-id presence flag — present via a
+// data column when the id has one, or via mask membership when it's a tag
+// (which has no column at all).
+func (t *Table) BakeOptional(ids []comp.ID, mask comp.Mask) (offsets []uintptr, present []bool) {
 	offsets = make([]uintptr, len(ids))
 	present = make([]bool, len(ids))
 	for i, id := range ids {
 		if col := t.getColumn(id); col != nil {
 			offsets[i] = col.Offset
 			present[i] = true
+		} else if mask.IsSet(id) {
+			present[i] = true // tag: present, no column, offset stays 0 (never dereferenced — size 0)
 		}
 	}
 	return offsets, present

--- a/internal/colstore/table_bake_test.go
+++ b/internal/colstore/table_bake_test.go
@@ -51,12 +51,31 @@ func TestTable_BakeOptional(t *testing.T) {
 
 	baked := tbl.BakeColumns(defs)
 
-	offsets, present := tbl.BakeOptional([]comp.ID{1, 99})
+	offsets, present := tbl.BakeOptional([]comp.ID{1, 99}, comp.Mask{})
 	if !present[0] || offsets[0] != baked[0].Offset {
 		t.Errorf("expected present[0]=true with offset %d, got present=%v offsets=%v", baked[0].Offset, present, offsets)
 	}
 	if present[1] {
 		t.Errorf("expected present[1]=false for an untracked component ID, got %v", present)
+	}
+}
+
+// TestTable_BakeOptional_TagViaMask guards the fallback path: a tag (no
+// column) is still reported present when the archetype's mask has its bit
+// set, with offset left at 0 (never dereferenced — tags are zero-size).
+func TestTable_BakeOptional_TagViaMask(t *testing.T) {
+	var tbl Table
+	tbl.Init(nil)
+
+	var mask comp.Mask
+	mask = mask.Set(7)
+
+	offsets, present := tbl.BakeOptional([]comp.ID{7, 8}, mask)
+	if !present[0] || offsets[0] != 0 {
+		t.Errorf("expected present[0]=true with offset 0 (tag, no column), got present=%v offsets=%v", present, offsets)
+	}
+	if present[1] {
+		t.Errorf("expected present[1]=false: neither a column nor a mask bit for ID 8, got %v", present)
 	}
 }
 

--- a/internal/comp/access_opt.go
+++ b/internal/comp/access_opt.go
@@ -33,7 +33,7 @@ func Exclude[T any]() AccessOpt {
 	}
 }
 
-// Optional registers T as a tracked column that never gates a match.
+// Optional registers T as a tracked column that never gates a match — works for a zero-size tag T too, tracked via the archetype mask instead of a column.
 func Optional[T any](col *iter.OptArrayRef[T]) AccessOpt {
 	return func(s *AccessSpec, mi *DefIndex) error {
 		col.Idx = len(s.OptCompInfos)

--- a/internal/comp/access_spec.go
+++ b/internal/comp/access_spec.go
@@ -59,7 +59,8 @@ func (s *AccessSpec) OptCompIDs() []ID {
 	return ids
 }
 
-// OptComp registers def as a data column that never gates a match.
+// OptComp registers def as a data column that never gates a match — a
+// zero-size def (tag) is tracked via the archetype mask instead of a column.
 func (s *AccessSpec) OptComp(def Def) error {
 	for _, existing := range s.OptCompInfos {
 		if existing.ID == def.ID {
@@ -73,9 +74,6 @@ func (s *AccessSpec) OptComp(def Def) error {
 	}
 	if slices.Contains(s.TagIDs, def.ID) {
 		return fmt.Errorf("component %s (ID: %d) is already required in this access spec, cannot also be optional", def.Type.String(), def.ID)
-	}
-	if def.Size == 0 {
-		return fmt.Errorf("cannot add %s: tags are not allowed as data columns", def.Type.String())
 	}
 	s.OptCompInfos = append(s.OptCompInfos, def)
 	return nil

--- a/internal/comp/access_spec_test.go
+++ b/internal/comp/access_spec_test.go
@@ -83,12 +83,15 @@ func TestAccessSpec_OptComp(t *testing.T) {
 		}
 	})
 
-	t.Run("rejects a tag (size 0) as an optional data column", func(t *testing.T) {
+	t.Run("accepts a tag (size 0) as an optional data column", func(t *testing.T) {
 		var s comp.AccessSpec
 		tagDef := comp.Def{ID: 1, Size: 0, Type: reflect.TypeFor[position]()}
 
-		if err := s.OptComp(tagDef); err == nil {
-			t.Error("expected an error when adding a zero-size def as an optional data column")
+		if err := s.OptComp(tagDef); err != nil {
+			t.Errorf("unexpected error adding a zero-size def as optional: %v", err)
+		}
+		if len(s.OptCompInfos) != 1 || s.OptCompInfos[0] != tagDef {
+			t.Errorf("expected OptCompInfos to contain tagDef, got %v", s.OptCompInfos)
 		}
 	})
 }

--- a/internal/query/baked_tables_catalog.go
+++ b/internal/query/baked_tables_catalog.go
@@ -13,7 +13,7 @@ type BakedTablesCatalog struct {
 // Add bakes the archetype into a BakedTable and registers it in the catalog;
 // optCompIDs are resolved the same way as compIDs but never gate the match.
 func (c *BakedTablesCatalog) Add(archetype *arch.Archetype, compIDs, optCompIDs []comp.ID) {
-	optOffsets, optPresent := archetype.Table.BakeOptional(optCompIDs)
+	optOffsets, optPresent := archetype.Table.BakeOptional(optCompIDs, archetype.Mask())
 	c.BakedTables = append(c.BakedTables, BakedTable{
 		ArchID:      archetype.Id,
 		Table:       &archetype.Table,

--- a/internal/query/matcher.go
+++ b/internal/query/matcher.go
@@ -135,11 +135,12 @@ func (m *Matcher) Seek(entID uid.UID64) bool {
 		return false
 	}
 	if entry.ArchID != m.seekLastArchID {
-		m.seekTable = &m.archCatalog.Archetypes[entry.ArchID].Table
+		archetype := &m.archCatalog.Archetypes[entry.ArchID]
+		m.seekTable = &archetype.Table
 		b := &m.seekBakes[entry.ArchID]
 		if b.offsets == nil {
 			b.offsets = m.seekTable.BakeOffsets(m.compIDs)
-			b.optOffsets, b.optPresent = m.seekTable.BakeOptional(m.optCompIDs)
+			b.optOffsets, b.optPresent = m.seekTable.BakeOptional(m.optCompIDs, archetype.Mask())
 		}
 		m.Cursor.Offsets = b.offsets
 		m.Cursor.OptOffsets = b.optOffsets

--- a/query_test.go
+++ b/query_test.go
@@ -2,6 +2,7 @@ package goke_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kjkrol/goke/v3"
 	"github.com/kjkrol/uid"
@@ -219,6 +220,81 @@ func TestQueryBuilder_Optional(t *testing.T) {
 			assert.Nil(t, velComp.At(cur), "expected nil At for eA (velocity absent)")
 		case eB:
 			assert.Equal(t, velocity{VX: 9, VY: 9}, *velComp.At(cur))
+		}
+	}
+}
+
+// TestQueryBuilder_Optional_Tag mirrors TestQueryBuilder_Optional but for a
+// zero-size tag (Processed) — Optional works the same for tags: it never
+// gates the match, and Present is the only meaningful signal (Slice/At
+// still return data-free values rather than nil when present).
+func TestQueryBuilder_Optional_Tag(t *testing.T) {
+	ecs := goke.New()
+	_ = ecs.RegComp[position]()
+	// Factory-time spawning still requires a real data column (AccessSpec.Comp
+	// is untouched by this change) — a tag is attached post-spawn via
+	// CmdBuf.AddOne, same as TestECS_UseCase's Processed usage.
+	processedID := ecs.RegComp[Processed]()
+
+	// eA: position only — Processed absent. eB: position, then tagged — present.
+	var eA, eB uid.UID64
+	var tagComp goke.OptComp[Processed]
+	var query *goke.Query
+	ecs.Setup(goke.SystemFn{OnInit: func(si *goke.SysInit) {
+		factoryA := si.NewFactory(new(goke.Comp[position]))
+		factoryA.Create(1)
+		factoryA.Next()
+		eA = factoryA.IDs[0]
+
+		factoryB := si.NewFactory(new(goke.Comp[position]))
+		factoryB.Create(1)
+		factoryB.Next()
+		eB = factoryB.IDs[0]
+
+		query = si.NewQueryBuilder(new(goke.Comp[position])).Optional(&tagComp).Build()
+	}})
+
+	tagHandle := ecs.RegSys(goke.SystemFn{OnUpdate: func(cb *goke.CmdBuf, _ time.Duration) {
+		cb.AddOne(eB, processedID, Processed{})
+	}})
+	ecs.SetPlan(func(ctx goke.RunCtx, d time.Duration) {
+		ctx.Run(tagHandle, d)
+		ctx.Sync()
+	})
+	ecs.Tick(time.Second)
+
+	seen := map[uid.UID64]bool{}
+	query.All()
+	for query.Next() {
+		cur := query.Cursor()
+		present := tagComp.Present(cur)
+		for _, e := range cur.IDs {
+			seen[e] = true
+			switch e {
+			case eA:
+				assert.False(t, present, "eA's chunk should report Processed absent")
+				assert.Nil(t, tagComp.Slice(cur), "expected nil Slice for eA's chunk")
+			case eB:
+				assert.True(t, present, "eB's chunk should report Processed present")
+				assert.Len(t, tagComp.Slice(cur), len(cur.IDs), "expected a data-free Slice sized to the chunk for a present tag")
+			}
+		}
+	}
+
+	// Optional never gates the match — both entities are matched by a query
+	// that only requires position.
+	assert.True(t, seen[eA])
+	assert.True(t, seen[eB])
+
+	// OptComp.At (Pick-mode) mirrors Slice's present/absent behavior.
+	query.Pick([]uid.UID64{eA, eB})
+	for query.Next() {
+		cur := query.Cursor()
+		switch query.Entity() {
+		case eA:
+			assert.Nil(t, tagComp.At(cur), "expected nil At for eA (Processed absent)")
+		case eB:
+			assert.NotNil(t, tagComp.At(cur), "expected non-nil At for eB (Processed present)")
 		}
 	}
 }


### PR DESCRIPTION
Let OptComp[T]/Optional[T]() track zero-size tags too, falling back to the archetype mask when a component has no data column, so a non-gating tag check no longer needs the two-query Include+Exclude workaround.